### PR TITLE
docker: Support self-contained images for Kubernetes deployments alongside local envs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,79 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image-name: immich-memories-notify
+            dockerfile: ./Dockerfile.dashboard
+          - image-name: immich-memories-notify-cli
+            dockerfile: ./Dockerfile
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Lowercase github.repository_owner for image tagging
+      - name: Get owner name in lowercase
+        id: owner
+        run: echo "owner=${OWNER,,}" >> $GITHUB_OUTPUT
+        env:
+          OWNER: ${{ github.repository_owner }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.owner }}/${{ matrix.image-name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,5 +75,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
+          build-args: |
+            COPY_SOURCE=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 # Create app directory
 WORKDIR /app
 
-# Source files are mounted as volume (not copied)
-# This allows easy editing without rebuilding
+# Copy source files
+COPY VERSION /app/VERSION
+COPY notify/ /app/notify/
 
 ENTRYPOINT ["python", "-m", "notify"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-# Immich Memories Notify
-# Lightweight Python container for sending memory notifications
+ARG COPY_SOURCE=false
 
-FROM python:3.11-alpine
+FROM python:3.11-alpine AS base
 
 # Install dependencies
 COPY requirements.txt /tmp/requirements.txt
@@ -10,9 +9,20 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt && rm /tmp/requirements.
 # Create app directory
 WORKDIR /app
 
-# Copy source files
+# Stage 1a: Do not copy files (upstream / local development)
+FROM base AS copy-false
+# Source files are mounted as volume (not copied)
+# This allows easy editing without rebuilding
+
+# Stage 1b: Copy files (production build / CI/CD)
+FROM base AS copy-true
 COPY VERSION /app/VERSION
 COPY notify/ /app/notify/
 
+# Final stage
+FROM copy-${COPY_SOURCE} AS final
+
 ENTRYPOINT ["python", "-m", "notify"]
 CMD []
+
+


### PR DESCRIPTION
## Description
This PR enables building self-contained container images suitable for environments like Kubernetes, without breaking current userspace.

### The Problem
Kubernetes requires container images where the application code is baked in. The current docker architecture does not support this since it relies on  always copying files (`COPY notify/ /app/notify/`) .

### The Solution
I introduced a conditional build stage via the `COPY_SOURCE` build argument (defaulting to `false`):
- **Registry Build (`COPY_SOURCE=true`)**: Files are copied so that the published image is self-contained and ready for Kubernetes or standalone runtimes.
- **Docker based env (Default / `COPY_SOURCE=false`)**: No source files are copied, preserving the volume-mounted development workflow and keeping build caching fast.